### PR TITLE
Fix for counter clockwise going twice as fast

### DIFF
--- a/src/EndlessPotentiometer.cpp
+++ b/src/EndlessPotentiometer.cpp
@@ -70,7 +70,7 @@ void EndlessPotentiometer::updateValues(int valueA, int valueB) {
   // Record the change.
   // Avoid values around zero and max as value has flat region. Instead use
   // the values in between which are more predictable and linear.
-  if (dirA != NOT_MOVING && dirB != NOT_MOVING) {
+   if (dirA != 0 && dirB != 0) {
     if ((valueA < adcMaxValue*0.8) && (valueA > adcMaxValue*0.2)) {
       valueChanged = direction*abs(valueA - previousValueA)/sensitivity;
     } else {
@@ -99,4 +99,5 @@ int EndlessPotentiometer::getValue(int value) {
 
     return value;
   }
+  return 0;
 }

--- a/src/EndlessPotentiometer.h
+++ b/src/EndlessPotentiometer.h
@@ -8,9 +8,9 @@
 class EndlessPotentiometer {
 public:
   enum Direction {
-    NOT_MOVING,
-    CLOCKWISE,
-    COUNTER_CLOCKWISE
+    COUNTER_CLOCKWISE = -1,
+    NOT_MOVING = 0,
+    CLOCKWISE = 1,
   };
 
   bool isMoving;


### PR DESCRIPTION
I encountered an issue with counter-clockwise going twice as fast. As COUNTER_CLOCKWISE enum was 2 a multiplication would also be twice as big.

Fixed it by specifically setting the integer values of the enums.

Also changed checking dirA with a type Direction enum, although technically correct it seems counterintuitive to compare a IndividualDirection enum with a Direction enum.

Added a return 0 as my IDE would complain about a function not returning anything in certain flows.